### PR TITLE
Change CMD ["help"] to ["--help"]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ ENV PATH "/usr/local/bin/zig:${PATH}"
 WORKDIR /app
 
 ENTRYPOINT ["/usr/local/bin/zig/zig"]
-CMD ["help"]
+CMD ["--help"]


### PR DESCRIPTION
```
$ sd run -it --rm euantorano/zig
Unrecognized command: help
See `/usr/local/bin/zig/zig --help` for detailed usage information
$ sd run -it --rm euantorano/zig --help
Usage: /usr/local/bin/zig/zig [command] [options]

Commands:
  build                        build project from build.zig
  ...
```